### PR TITLE
Modular dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,18 @@ release:
 	echo RELEASE_FILES=$(RELEASE_FILES)
 	echo ' '
 	$(PERL) $(TOP)/configure/makeReleaseConsistent.pl $(SUPPORT) $(EPICS_BASE) $(MASTER_FILE) $(RELEASE_FILES)
+
+
+.PHONY: all_adl all_edl all_ui all_opi
+	
+all_adl:
+	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'adl'
+	
+all_edl:
+	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'edl'
+	
+all_ui:
+	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'ui,qss'
+	
+all_opi:
+	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'opi'

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ include $(TOP)/configure/CONFIG
 
 DIRS := $(DIRS) $(filter-out $(DIRS), configure)
 
+GET_DEPENDS := $(SUPPORT)/utils/depends.pl $(call FIND_TOOL,convertRelease.pl)
+
 define  MODULE_defined
   ifdef $(1)
   SUPPORT_DIRS  += $($(1))
@@ -52,10 +54,9 @@ define  MODULE_defined
   RELEASE_FILES += $(wildcard $($(1))/configure/RELEASE.local)
   RELEASE_FILES += $(wildcard $($(1))/configure/RELEASE.local.$(EPICS_HOST_ARCH))
   RELEASE_FILES += $(wildcard $($(1))/configure/RELEASE.$(EPICS_HOST_ARCH))
+  $(eval $$($(1))_DEPEND_DIRS := $(shell $(GET_DEPENDS) $($(1)) $(1) "$(MODULE_LIST)"))
   endif  
 endef
-
-GET_DEPENDS := $(SUPPORT)/utils/depends.pl $(call FIND_TOOL,convertRelease.pl)
 
 ###### Support Modules ######
 
@@ -70,7 +71,6 @@ MODULE_LIST += MCA VME MOTOR AREA_DETECTOR
 MODULE_LIST += SOFTGLUEZYNQ MEASCOMP CAMAC
 MODULE_LIST += QUADEM DXP DXPSITORO XXX
 $(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-$(foreach mod, $(MODULE_LIST), $(eval $$($(mod))_DEPEND_DIRS := $(shell $(GET_DEPENDS) $($(mod)) $(mod) "$(MODULE_LIST)")))
 
 ################### End of Support-Modules #####################
 
@@ -92,6 +92,3 @@ release:
 	echo RELEASE_FILES=$(RELEASE_FILES)
 	echo ' '
 	$(PERL) $(TOP)/configure/makeReleaseConsistent.pl $(SUPPORT) $(EPICS_BASE) $(MASTER_FILE) $(RELEASE_FILES)
-
-test:
-	@echo $($(XXX)_DEPEND_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -55,101 +55,26 @@ define  MODULE_defined
   endif  
 endef
 
+GET_DEPENDS := $(SUPPORT)/utils/depends.pl $(call FIND_TOOL,convertRelease.pl)
 
-###### 1st Tier Support Modules - Only Depend on EPICS BASE ######
+###### Support Modules ######
 
-MODULE_LIST =  SNCSEQ ALLEN_BRADLEY
-MODULE_LIST += IPAC AUTOSAVE ALIVE CAPUTRECORDER
-MODULE_LIST += ETHERIP
+MODULE_LIST =  SNCSEQ ALLEN_BRADLEY IPAC 
+MODULE_LIST += AUTOSAVE ALIVE CAPUTRECORDER
+MODULE_LIST += ETHERIP SSCAN DEVIOCSTATS
+MODULE_LIST += YOKOGAWA_DAS ASYN CALC BUSY
+MODULE_LIST += STD DAC128V IP330 IPUNIDIG 
+MODULE_LIST += LOVE IP OPTICS STREAM MODBUS 
+MODULE_LIST += VAC SOFTGLUE LUA DELAYGEN
+MODULE_LIST += MCA VME MOTOR AREA_DETECTOR
+MODULE_LIST += SOFTGLUEZYNQ MEASCOMP CAMAC
+MODULE_LIST += QUADEM DXP DXPSITORO XXX
 $(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-###### 1.5 Tier Support Modules - Only Depend on 1st Tier ######
-# sscan now depends on seq, via scanProgress.st, but sscan can also build
-# without seq. Yokogawa DAS can also build without seq.
-MODULE_LIST = SSCAN DEVIOCSTATS YOKOGAWA_DAS
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-$(SSCAN)_DEPEND_DIRS     = $(SNCSEQ)
-$(DEVIOCSTATS)_DEPEND_DIRS     = $(SNCSEQ)
-$(YOKOGAWA_DAS)_DEPEND_DIRS = $(SNCSEQ)
-
-###### 2nd Tier Support Modules - Only Depend on 1st Tier ########
-
-MODULE_LIST  = ASYN CALC
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(ASYN)_DEPEND_DIRS = $(SNCSEQ) $(IPAC)
-$(CALC)_DEPEND_DIRS = $(SNCSEQ) $(SSCAN)
-
-################### 3rd Tier Support Modules #####################
-
-MODULE_LIST  = BUSY STD DAC128V IP330 IPUNIDIG LOVE
-MODULE_LIST += IP OPTICS STREAM MODBUS VAC SOFTGLUE
-MODULE_LIST += LUA
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(BUSY)_DEPEND_DIRS     = $(ASYN)
-$(STD)_DEPEND_DIRS      = $(ASYN) $(SNCSEQ)
-$(DAC128V)_DEPEND_DIRS  = $(ASYN) $(IPAC)
-$(IP330)_DEPEND_DIRS    = $(ASYN) $(IPAC)
-$(IPUNIDIG)_DEPEND_DIRS = $(ASYN) $(IPAC)
-$(LOVE)_DEPEND_DIRS     = $(ASYN) $(IPAC)
-$(IP)_DEPEND_DIRS       = $(ASYN) $(IPAC) $(SNCSEQ)
-$(OPTICS)_DEPEND_DIRS   = $(ASYN) $(SNCSEQ)
-$(STREAM)_DEPEND_DIRS   = $(ASYN) $(CALC) $(SSCAN)
-$(MODBUS)_DEPEND_DIRS   = $(ASYN)
-$(VAC)_DEPEND_DIRS      = $(ASYN) $(IPAC)
-$(SOFTGLUE)_DEPEND_DIRS = $(ASYN) $(IPAC)
-$(LUA)_DEPEND_DIRS      = $(ASYN)
-
-################### 4th Tier Support Modules #####################
-
-MODULE_LIST  = DELAYGEN MCA VME MOTOR AREA_DETECTOR SOFTGLUEZYNQ
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(DELAYGEN)_DEPEND_DIRS = $(ASYN) $(AUTOSAVE) $(CALC) $(IP) $(IPAC) $(STREAM) 
-$(MCA)_DEPEND_DIRS      = $(ASYN) $(AUTOSAVE) $(BUSY) $(CALC) $(SNCSEQ) $(SSCAN) $(STD)
-$(VME)_DEPEND_DIRS      = $(SNCSEQ) $(STD)
-$(MOTOR)_DEPEND_DIRS    = $(ASYN) $(BUSY) $(IPAC) $(SNCSEQ) 
-$(AREA_DETECTOR)_DEPEND_DIRS = $(ASYN) $(AUTOSAVE) $(BUSY) $(CALC) $(SSCAN)
-$(SOFTGLUEZYNQ)_DEPEND_DIRS = $(ASYN) $(SNCSEQ) $(STD)
-#$(EBRICK)_DEPEND_DIRS   = $(ASYN) $(AUTOSAVE) $(CALC) $(SNCSEQ) $(SSCAN) $(STD)
-
-################### 4.5th Tier Support Modules #####################
-
-MODULE_LIST  = MEASCOMP
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(MEASCOMP)_DEPEND_DIRS   = $(ASYN) $(CALC) $(STD) $(MCA) $(BUSY) $(SSCAN) $(AUTOSAVE) $(SNCSEQ)  
-
-################### 5th Tier Support Modules #####################
-# The conditional below should be a target arch, but those are not
-# defined at this level.
-MODULE_LIST = CAMAC QUADEM
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(CAMAC)_DEPEND_DIRS    = $(CALC) $(SSCAN) $(MOTOR) $(STD)
-$(QUADEM)_DEPEND_DIRS   = $(AREA_DETECTOR) $(ASYN) $(AUTOSAVE) $(BUSY) $(IPAC) $(IPUNIDIG) $(MCA) $(SNCSEQ)
-
-################### 6th Tier Support Modules #####################
-# The conditional below should be a target arch, but those are not
-# defined at this level.
-MODULE_LIST = DXP DXPSITORO
-$(foreach mod, $(MODULE_LIST), $(eval $(call MODULE_defined,$(mod)) ))
-
-$(DXP)_DEPEND_DIRS = $(AREA_DETECTOR) $(ASYN) $(AUTOSAVE) $(BUSY) $(CALC) $(CAMAC) $(MCA) $(SNCSEQ) $(SSCAN)
-$(DXPSITORO)_DEPEND_DIRS = $(AREA_DETECTOR) $(ASYN) $(AUTOSAVE) $(BUSY) $(CALC) $(CAMAC) $(MCA) $(SNCSEQ) $(SSCAN)
+$(foreach mod, $(MODULE_LIST), $(eval $$($(mod))_DEPEND_DIRS := $(shell $(GET_DEPENDS) $($(mod)) $(mod) "$(MODULE_LIST)")))
 
 ################### End of Support-Modules #####################
 
 DIRS = $(SUPPORT_DIRS)
-
-################### User Modules #####################
-
-ifdef XXX
-DIRS += $(XXX)
-RELEASE_FILES += $(XXX)/configure/RELEASE
-$(XXX)_DEPEND_DIRS = $(SUPPORT_DIRS)
-endif
 
 ACTIONS += uninstall realuninstall distclean cvsclean
 
@@ -168,16 +93,5 @@ release:
 	echo ' '
 	$(PERL) $(TOP)/configure/makeReleaseConsistent.pl $(SUPPORT) $(EPICS_BASE) $(MASTER_FILE) $(RELEASE_FILES)
 
-.PHONY: all_adl all_edl all_ui all_opi
-	
-all_adl:
-	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'adl'
-	
-all_edl:
-	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'edl'
-	
-all_ui:
-	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'ui,qss'
-	
-all_opi:
-	$(PERL) $(TOP)/utils/copyScreens.pl $(SUPPORT) 'opi'
+test:
+	@echo $($(XXX)_DEPEND_DIRS)


### PR DESCRIPTION
Change Makefile to build the graph of interdependencies between modules automatically from their RELEASE files. Relies on a new script depends.pl that has been added to utils (https://github.com/EPICS-synApps/utils/blob/master/depends.pl) which, in turn, uses convertRelease.pl from base.

Depends.pl takes in the path to convertRelease, the path to the module, the name of the module, and the list of potential modules to build against. It reads the module's RELEASE file for any macros defined, removes any macros that aren't one of the modules in MODULE_LIST and removes macros that have the same name as the module itself. What remains should be a list of the directories that the module needs to build against.

I have found one issue with this, where AreaDetector doesn't require autosave, busy, etc to build its core, but does to build its IOC's. The macros aren't defined in RELEASE, but in RELEASE_PRODS.local, which is only included by the IOC's. Though, this seems more like an issue to be solved with tweaks to AreaDetector rather than changing something here.