### PR TITLE
Fix link rot (get seq package from web.archive.org)

### DIFF
--- a/assemble_synApps.sh
+++ b/assemble_synApps.sh
@@ -491,7 +491,11 @@ if [[ $SNCSEQ ]]
 then
 
 	# seq
-	wget http://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-$SNCSEQ.tar.gz
+
+	# www-csr.bessy.de is dead :-(
+	# get the seq package from web.archive.org until there is a working host again
+	# wget http://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-$SNCSEQ.tar.gz
+	wget http://web.archive.org/web/20230128080042/http://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-$SNCSEQ.tar.gz
 	tar zxf seq-$SNCSEQ.tar.gz
 	
 	# The synApps build can't handle '.'


### PR DESCRIPTION
`www-csr.bessy.de` is down, so `assemble_synApps.sh` doesn't work anymore.

As a workaround, this PR changes the URL for a web.archive.org based one.

Not sure if there is a official repository for `seq`. To get it from `web.archive.org` may not be a permanent solution, but at least it makes the script work again.